### PR TITLE
cargo: upgrade rocksdb and io-uring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - run: cargo build --verbose
+      - run: RUSTFLAGS="--cfg=io_uring_skip_arch_check" cargo build --verbose
 
   build_i686:
     name: build rust i686
@@ -37,4 +37,4 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y g++-multilib gcc-multilib build-essential pkg-config libclang-dev
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }} && rustup target add i686-unknown-linux-gnu
-      - run: cargo build --verbose --target i686-unknown-linux-gnu
+      - run: RUSTFLAGS="--cfg=io_uring_skip_arch_check" cargo build --verbose --target i686-unknown-linux-gnu

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
 dependencies = [
  "bitflags 2.8.0",
  "cexpr",
@@ -797,11 +797,10 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab01638bb6a279897b7691f87f3f3c232451711fd419a69ced980ce61074fa46"
+checksum = "3c2f96dfbc20c12b9b4f12eef60472d8c29b9c3f29463570dcb47e4a48551168"
 dependencies = [
- "bindgen 0.69.5",
  "bitflags 2.8.0",
  "cfg-if",
  "libc",
@@ -867,11 +866,11 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.17.1+9.9.3"
+version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7869a512ae9982f4d46ba482c2a304f1efd80c6412a3d4bf57bb79a619679f"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen 0.72.0",
  "bzip2-sys",
  "cc",
  "libc",
@@ -882,16 +881,16 @@ dependencies = [
 
 [[package]]
 name = "libublk"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8674d57dc6a881d44b722618a99c11d310747b6e6731b1f0c6d950edbb33cda3"
+checksum = "195076bfaf06fb58340ea959d4d3961d79840bb602b079e9a7e88246a9e99165"
 dependencies = [
  "anyhow",
  "bindgen 0.69.5",
  "bitflags 2.8.0",
  "bitmaps",
  "derive_setters",
- "io-uring 0.7.4",
+ "io-uring 0.7.6",
  "libc",
  "log",
  "regex",
@@ -1277,9 +1276,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rocksdb"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec73b20525cb235bad420f911473b69f9fe27cc856c5461bccd7e4af037f43"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -1287,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "rublk"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1300,7 +1299,7 @@ dependencies = [
  "env_logger",
  "futures",
  "ilog",
- "io-uring 0.7.4",
+ "io-uring 0.7.6",
  "libc",
  "libublk",
  "log",
@@ -1852,7 +1851,6 @@ version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
- "bindgen 0.71.1",
  "cc",
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 qcow2-rs = "0.1"
-libublk = "0.4.1"
+libublk = "0.4.2"
 clap = { version = "4.3", features = ["derive"] }
 clap_derive = "4.3"
 libc = "0.2"
@@ -30,7 +30,7 @@ env_logger = "0.9"
 backtrace = "0.3"
 daemonize = "0.5"
 nix = "0.26.2"
-io-uring = "=0.7.4"
+io-uring = "=0.7.6"
 ilog = "1.0.1"
 shared_memory = "0.12.4"
 rand = "0.8.4"
@@ -40,7 +40,7 @@ async-trait = "0.1"
 rustversion = "1.0.14"
 parse-size = "1.1.0"
 bitflags = "2.8"
-rocksdb = "0.23.0"
+rocksdb = "0.24.0"
 bincode = "1.3.3"
 
 [dev-dependencies]


### PR DESCRIPTION
Meantime set RUSTFLAGS="--cfg=io_uring_skip_arch_check" for avoiding io-uring build failure:

error: The prebuilt `sys.rs` may not be compatible with your target,
       please use bindgen feature to generate new `sys.rs` of your arch
       or use `--cfg=io_uring_skip_arch_check` to skip the check.
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/io-uring-0.7.6/src/sys/mod.rs:27:1
   |
27 | / compile_error!(
28 | |     "The prebuilt `sys.rs` may not be compatible with your target,
29 | | please use bindgen feature to generate new `sys.rs` of your arch
30 | | or use `--cfg=io_uring_skip_arch_check` to skip the check."
31 | | );
   | |_^