### PR TITLE
Add Notifier to offload with smol::unblock()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "rublk"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rublk"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 description = "Rust ublk generic targets"
 authors = ["Ming Lei <tom.leiming@gmail.com>"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,8 @@ mod args;
 #[cfg(feature = "compress")]
 mod compress;
 mod r#loop;
+#[cfg(feature = "compress")]
+mod notifier;
 mod null;
 #[cfg(feature = "vram")]
 mod opencl;

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -1,0 +1,34 @@
+use libublk::{io::UblkQueue, UblkError};
+use nix::sys::eventfd::{EfdFlags, EventFd};
+use std::os::fd::AsRawFd;
+
+pub(crate) struct Notifier {
+    eventfd: EventFd,
+}
+
+impl Notifier {
+    pub fn new() -> Result<Self, std::io::Error> {
+        let eventfd = EventFd::from_value_and_flags(0, EfdFlags::EFD_CLOEXEC)?;
+        Ok(Notifier { eventfd })
+    }
+
+    pub fn notify(&self) -> anyhow::Result<()> {
+        nix::unistd::write(&self.eventfd, &1u64.to_le_bytes())?;
+        Ok(())
+    }
+
+    pub async fn event_read(&self, q: &UblkQueue<'_>) -> Result<(), UblkError> {
+        let mut buf = [0u8; 8];
+        let eventfd = self.eventfd.as_raw_fd();
+        let sqe =
+            io_uring::opcode::Read::new(io_uring::types::Fd(eventfd), buf.as_mut_ptr(), 8).build();
+        log::debug!("before eventfd reading");
+        let res = q.ublk_submit_sqe(sqe).await;
+
+        if res < 8 {
+            Err(UblkError::OtherError(-libc::EIO))
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -1,19 +1,27 @@
 use libublk::{io::UblkQueue, UblkError};
 use nix::sys::eventfd::{EfdFlags, EventFd};
+use std::cell::RefCell;
 use std::os::fd::AsRawFd;
 
 pub(crate) struct Notifier {
     eventfd: EventFd,
+    counter: RefCell<u32>,
 }
 
 impl Notifier {
     pub fn new() -> Result<Self, std::io::Error> {
         let eventfd = EventFd::from_value_and_flags(0, EfdFlags::EFD_CLOEXEC)?;
-        Ok(Notifier { eventfd })
+        Ok(Notifier {
+            eventfd,
+            counter: RefCell::new(0),
+        })
     }
 
     pub fn notify(&self) -> anyhow::Result<()> {
-        nix::unistd::write(&self.eventfd, &1u64.to_le_bytes())?;
+        let old_value = self.counter.replace_with(|&mut old| old + 1);
+        if old_value == 0 {
+            nix::unistd::write(&self.eventfd, &1u64.to_le_bytes())?;
+        }
         Ok(())
     }
 
@@ -24,6 +32,8 @@ impl Notifier {
             io_uring::opcode::Read::new(io_uring::types::Fd(eventfd), buf.as_mut_ptr(), 8).build();
         log::debug!("before eventfd reading");
         let res = q.ublk_submit_sqe(sqe).await;
+
+        self.counter.replace(0);
 
         if res < 8 {
             Err(UblkError::OtherError(-libc::EIO))


### PR DESCRIPTION
- add Notifier to notify uring thread after unblock().await returns.
-  optimize eventfd write by doing it in batch way